### PR TITLE
Fix stub class issue

### DIFF
--- a/src/stub-date-class.test.js
+++ b/src/stub-date-class.test.js
@@ -8,9 +8,9 @@ test('It should create new date', () => {
   const currentDate = new Date('2019-05-14T11:01:58.135Z');
   realDate = Date;
   global.Date = class extends Date {
-    constructor(date) {
-      if (date) {
-        return super(date);
+    constructor(...args) {
+      if (args.length > 0) {
+        return super(...args);
       }
 
       return currentDate;


### PR DESCRIPTION
Date constructor may be called with a timestamp, so it could be used like `new Date(0)`, which shouldn't return the mocked date.